### PR TITLE
Add in official support for Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial  # Specification is necessary for 3.7.
 language: python
 python:
   - "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - "3.6"
+  - "3.7"
 
 install:
   - pip install -r requirements.txt
@@ -8,3 +9,4 @@ install:
 
 script:
   - python ./tests/eval_test.py
+  - python ./tests/methods_test.py

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-**pylift** has only been tested on Python **3.6**. It currently requires the following package versions:
+**pylift** has only been tested on Python **3.6** and **3.7**. It currently requires the following package versions:
 
 ```
 matplotlib >= 2.1.0


### PR DESCRIPTION
- Revises `.travis.yml` file so travis CI runs tests on python 3.7. 
- Docs adjusted accordingly.