### PR TITLE
Fix check of rho argument to sim_pte

### DIFF
--- a/pylift/generate_data.py
+++ b/pylift/generate_data.py
@@ -109,7 +109,7 @@ def sim_pte(N=1000, n_features=20, beta=None, rho=0, sigma=np.sqrt(2), beta_den=
     if p < 4:
         raise ValueError("uplift: The number predictors must be equal or greater than 4")
 
-    if rho < 0 | rho > 1:
+    if rho < 0 or rho > 1:
         raise ValueError("uplift: rho must be between 0 and 1")
 
     if sigma < 0:


### PR DESCRIPTION
The expression to check if the rho argument to sim_pte is between 0 and 1 used the bitwise OR operator instead of the logical OR operator. Due to operator precedence of the bitwise OR operator, the bitwise operator is evaluated first before the comparisons.  '0 | rho' will evaluate to the value of rho, given rho is an integer, making the conditional equivalently rho < rho > 1 which will always evaluate to False no matter the value of rho. If rho is a float, which would be common, a TypeError exception would be thrown as you can't perform bitwise OR on a float. To correctly check that rho is between 0 and 1, the bitwise OR operator is replaced with the logical OR operator 'or'.